### PR TITLE
Generate the JSON representation for an object's JSON schema correctly

### DIFF
--- a/blocks/basic.cf.go
+++ b/blocks/basic.cf.go
@@ -17,7 +17,7 @@ func (i BasicInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Basic",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/blocks/exec.cf.go
+++ b/blocks/exec.cf.go
@@ -16,8 +16,9 @@ type ExecInterpreter struct {
 func (i ExecInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "Exec",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"exit_code": "exitCode"},
+			Name:              "Exec",
+			Parameters: map[string]schema.Schema{
 				"cmd": &schema.String{},
 				"dir": &schema.String{},
 				"env": &schema.Array{
@@ -54,8 +55,7 @@ func (i ExecInterpreter) Schema() schema.Schema {
 					Ref: "http://conflow.schema/github.com/conflowio/conflow/blocks.Stream",
 				},
 			},
-			PropertyNames: map[string]string{"exit_code": "exitCode"},
-			Required:      []string{"cmd", "stdout", "stderr"},
+			Required: []string{"cmd", "stdout", "stderr"},
 		}
 	}
 	return i.s

--- a/blocks/fail.cf.go
+++ b/blocks/fail.cf.go
@@ -17,7 +17,7 @@ func (i FailInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Fail",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/blocks/gunzip.cf.go
+++ b/blocks/gunzip.cf.go
@@ -18,7 +18,7 @@ func (i GunzipInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Gunzip",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/blocks/gzip.cf.go
+++ b/blocks/gzip.cf.go
@@ -18,7 +18,7 @@ func (i GzipInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Gzip",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/blocks/import.cf.go
+++ b/blocks/import.cf.go
@@ -20,7 +20,7 @@ func (i ImportInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
 			Name: "Import",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/blocks/module.go
+++ b/blocks/module.go
@@ -43,7 +43,7 @@ func (m *module) Run(ctx context.Context) (conflow.Result, error) {
 		return nil, err
 	}
 
-	for propertyName, property := range m.interpreter.Schema().(schema.ObjectKind).GetProperties() {
+	for propertyName, property := range m.interpreter.Schema().(schema.ObjectKind).GetParameters() {
 		if property.GetReadOnly() {
 			m.params[conflow.ID(propertyName)] = m.interpreter.Param(value.(conflow.Block), conflow.ID(propertyName))
 		}
@@ -58,7 +58,7 @@ func NewModuleInterpreter(
 	node parsley.Node,
 ) conflow.BlockInterpreter {
 	s := interpreter.Schema().Copy().(*schema.Object)
-	for _, p := range s.Properties {
+	for _, p := range s.Parameters {
 		p.(schema.MetadataAccessor).SetAnnotation(conflow.AnnotationUserDefined, "")
 	}
 

--- a/blocks/print.cf.go
+++ b/blocks/print.cf.go
@@ -20,7 +20,7 @@ func (i PrintInterpreter) Schema() schema.Schema {
 				Description: "It will write a string to the standard output",
 			},
 			Name: "Print",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/blocks/println.cf.go
+++ b/blocks/println.cf.go
@@ -20,7 +20,7 @@ func (i PrintlnInterpreter) Schema() schema.Schema {
 				Description: "It will write a string followed by a new line to the standard output",
 			},
 			Name: "Println",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/blocks/range.cf.go
+++ b/blocks/range.cf.go
@@ -17,7 +17,7 @@ func (i RangeInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Range",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"entry": &schema.Reference{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/eval_stage": "init", "block.conflow.io/generated": "true"},

--- a/blocks/range_entry.cf.go
+++ b/blocks/range_entry.cf.go
@@ -17,7 +17,7 @@ func (i RangeEntryInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "RangeEntry",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/blocks/sleep.cf.go
+++ b/blocks/sleep.cf.go
@@ -18,7 +18,7 @@ func (i SleepInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Sleep",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"duration": &schema.TimeDuration{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/value": "true"},

--- a/blocks/stream.cf.go
+++ b/blocks/stream.cf.go
@@ -17,8 +17,9 @@ type StreamInterpreter struct {
 func (i StreamInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "Stream",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"stream": "Stream"},
+			Name:              "Stream",
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -28,7 +29,6 @@ func (i StreamInterpreter) Schema() schema.Schema {
 				},
 				"stream": &schema.ByteStream{},
 			},
-			PropertyNames: map[string]string{"stream": "Stream"},
 		}
 	}
 	return i.s

--- a/blocks/tick.cf.go
+++ b/blocks/tick.cf.go
@@ -17,7 +17,7 @@ func (i TickInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Tick",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/blocks/ticker.cf.go
+++ b/blocks/ticker.cf.go
@@ -18,7 +18,7 @@ func (i TickerInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Ticker",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/block/container.go
+++ b/conflow/block/container.go
@@ -151,7 +151,7 @@ func (c *Container) Value() (interface{}, parsley.Error) {
 // Param returns with the parameter value
 func (c *Container) Param(name conflow.ID) interface{} {
 	s := c.node.Interpreter().Schema()
-	if p, ok := s.(schema.ObjectKind).GetProperties()[string(name)]; ok {
+	if p, ok := s.(schema.ObjectKind).GetParameters()[string(name)]; ok {
 		if !IsBlockSchema(p) {
 			return c.node.Interpreter().Param(c.block, name)
 		}
@@ -503,7 +503,7 @@ func (c *Container) setChild(result conflow.Container) parsley.Error {
 		name := node.Name()
 
 		s := c.node.Interpreter().Schema()
-		if _, ok := s.(schema.ObjectKind).GetProperties()[string(name)]; ok {
+		if _, ok := s.(schema.ObjectKind).GetParameters()[string(name)]; ok {
 			if err := c.node.Interpreter().SetParam(c.block, node.Name(), value); err != nil {
 				return parsley.NewError(r.Node().Pos(), err)
 			}
@@ -550,7 +550,7 @@ func (c *Container) PublishBlock(block conflow.Block, f func() error) (bool, err
 
 	nodeContainer, ok := c.children[blockID]
 	propertyName := string(nodeContainer.Node().(conflow.BlockNode).ParameterName())
-	if !ok || c.Node().Schema().(*schema.Object).Properties[propertyName].GetAnnotation(conflow.AnnotationGenerated) != "true" {
+	if !ok || c.Node().Schema().(*schema.Object).Parameters[propertyName].GetAnnotation(conflow.AnnotationGenerated) != "true" {
 		return false, fmt.Errorf("%q block does not exist or is not marked as generated", blockID)
 	}
 

--- a/conflow/block/fixtures/block_simple.cf.go
+++ b/conflow/block/fixtures/block_simple.cf.go
@@ -16,8 +16,9 @@ type BlockSimpleInterpreter struct {
 func (i BlockSimpleInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockSimple",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"id_field": "IDField", "value": "Value"},
+			Name:              "BlockSimple",
+			Parameters: map[string]schema.Schema{
 				"id_field": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -31,7 +32,6 @@ func (i BlockSimpleInterpreter) Schema() schema.Schema {
 					},
 				},
 			},
-			PropertyNames: map[string]string{"id_field": "IDField", "value": "Value"},
 		}
 	}
 	return i.s

--- a/conflow/block/fixtures/block_value_required.cf.go
+++ b/conflow/block/fixtures/block_value_required.cf.go
@@ -16,8 +16,9 @@ type BlockValueRequiredInterpreter struct {
 func (i BlockValueRequiredInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockValueRequired",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"id_field": "IDField", "value": "Value"},
+			Name:              "BlockValueRequired",
+			Parameters: map[string]schema.Schema{
 				"id_field": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -31,8 +32,7 @@ func (i BlockValueRequiredInterpreter) Schema() schema.Schema {
 					},
 				},
 			},
-			PropertyNames: map[string]string{"id_field": "IDField", "value": "Value"},
-			Required:      []string{"value"},
+			Required: []string{"value"},
 		}
 	}
 	return i.s

--- a/conflow/block/fixtures/block_with_default.cf.go
+++ b/conflow/block/fixtures/block_with_default.cf.go
@@ -16,8 +16,9 @@ type BlockWithDefaultInterpreter struct {
 func (i BlockWithDefaultInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockWithDefault",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"id_field": "IDField", "value": "Value"},
+			Name:              "BlockWithDefault",
+			Parameters: map[string]schema.Schema{
 				"id_field": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -32,7 +33,6 @@ func (i BlockWithDefaultInterpreter) Schema() schema.Schema {
 					Default: schema.StringPtr("foo"),
 				},
 			},
-			PropertyNames: map[string]string{"id_field": "IDField", "value": "Value"},
 		}
 	}
 	return i.s

--- a/conflow/block/fixtures/block_with_interface.cf.go
+++ b/conflow/block/fixtures/block_with_interface.cf.go
@@ -16,8 +16,9 @@ type BlockWithInterfaceInterpreter struct {
 func (i BlockWithInterfaceInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockWithInterface",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"block": "Block", "blocks": "Blocks", "id_field": "IDField"},
+			Name:              "BlockWithInterface",
+			Parameters: map[string]schema.Schema{
 				"block": &schema.Reference{
 					Ref: "http://conflow.schema/github.com/conflowio/conflow/conflow.Block",
 				},
@@ -34,7 +35,6 @@ func (i BlockWithInterfaceInterpreter) Schema() schema.Schema {
 					Format: "conflow.ID",
 				},
 			},
-			PropertyNames: map[string]string{"block": "Block", "blocks": "Blocks", "id_field": "IDField"},
 		}
 	}
 	return i.s

--- a/conflow/block/fixtures/block_with_many_block.cf.go
+++ b/conflow/block/fixtures/block_with_many_block.cf.go
@@ -16,8 +16,9 @@ type BlockWithManyBlockInterpreter struct {
 func (i BlockWithManyBlockInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockWithManyBlock",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"block_simple": "BlockSimple", "id_field": "IDField"},
+			Name:              "BlockWithManyBlock",
+			Parameters: map[string]schema.Schema{
 				"block_simple": &schema.Array{
 					Items: &schema.Reference{
 						Metadata: schema.Metadata{
@@ -34,7 +35,6 @@ func (i BlockWithManyBlockInterpreter) Schema() schema.Schema {
 					Format: "conflow.ID",
 				},
 			},
-			PropertyNames: map[string]string{"block_simple": "BlockSimple", "id_field": "IDField"},
 		}
 	}
 	return i.s

--- a/conflow/block/fixtures/block_with_one_block.cf.go
+++ b/conflow/block/fixtures/block_with_one_block.cf.go
@@ -16,8 +16,9 @@ type BlockWithOneBlockInterpreter struct {
 func (i BlockWithOneBlockInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockWithOneBlock",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"block_simple": "BlockSimple", "id_field": "IDField"},
+			Name:              "BlockWithOneBlock",
+			Parameters: map[string]schema.Schema{
 				"block_simple": &schema.Reference{
 					Metadata: schema.Metadata{
 						Pointer: true,
@@ -32,7 +33,6 @@ func (i BlockWithOneBlockInterpreter) Schema() schema.Schema {
 					Format: "conflow.ID",
 				},
 			},
-			PropertyNames: map[string]string{"block_simple": "BlockSimple", "id_field": "IDField"},
 		}
 	}
 	return i.s

--- a/conflow/block/generator/generate_interpreter.go
+++ b/conflow/block/generator/generate_interpreter.go
@@ -67,11 +67,8 @@ func GenerateInterpreter(
 				return s.DefaultValue() != nil
 			})
 		},
-		"getPropertyName": func(name string) string {
-			if p, ok := params.Schema.(schema.ObjectKind).GetPropertyNames()[name]; ok {
-				return p
-			}
-			return name
+		"getFieldName": func(name string) string {
+			return params.Schema.(schema.ObjectKind).GetFieldName(name)
 		},
 		"getType": func(s schema.Schema) string {
 			return s.GoType(params.Imports)
@@ -147,7 +144,7 @@ func generateTemplateParams(
 	}
 
 	var idPropertyName, valuePropertyName string
-	for name, property := range s.Schema.(schema.ObjectKind).GetProperties() {
+	for name, property := range s.Schema.(schema.ObjectKind).GetParameters() {
 		switch {
 		case property.GetAnnotation(conflow.AnnotationID) == "true":
 			idPropertyName = name

--- a/conflow/block/generator/interpreter_template.go
+++ b/conflow/block/generator/interpreter_template.go
@@ -57,10 +57,10 @@ func (i {{ .Name }}Interpreter) Schema() schema.Schema {
 func (i {{ .Name }}Interpreter) CreateBlock(id conflow.ID, blockCtx *conflow.BlockContext) conflow.Block {
 	return &{{ .NameSelector }}{{ .Name }}{
 		{{ if .IDPropertyName -}}
-		{{ getPropertyName .IDPropertyName }}: id,
+		{{ getFieldName .IDPropertyName }}: id,
 		{{ end -}}
-		{{ range $name, $schema := filterDefaults (filterParams .Schema.GetProperties) -}}
-		{{ getPropertyName $name }}: {{ printf "%#v" .DefaultValue }},
+		{{ range $name, $schema := filterDefaults (filterParams .Schema.GetParameters) -}}
+		{{ getFieldName $name }}: {{ printf "%#v" .DefaultValue }},
 		{{ end -}}
 		{{ range .Dependencies -}}
 		{{ .FieldName }}: blockCtx.{{ title .Name }}(),
@@ -85,9 +85,9 @@ func (i {{.Name}}Interpreter) ParseContext(ctx *conflow.ParseContext) *conflow.P
 
 func (i {{ .Name }}Interpreter) Param(b conflow.Block, name conflow.ID) interface{} {
 	switch name {
-	{{ range $name, $property := filterParams .Schema.GetProperties -}}
+	{{ range $name, $property := filterParams .Schema.GetParameters -}}
 	case "{{ $name }}":
-		return b.(*{{ $root.NameSelector }}{{ $root.Name }}).{{ getPropertyName $name }}
+		return b.(*{{ $root.NameSelector }}{{ $root.Name }}).{{ getFieldName $name }}
 	{{ end -}}
 	default:
 		panic(fmt.Errorf("unexpected parameter %q in {{ .Name }}", name))
@@ -95,12 +95,12 @@ func (i {{ .Name }}Interpreter) Param(b conflow.Block, name conflow.ID) interfac
 }
 
 func (i {{ .Name }}Interpreter) SetParam(block conflow.Block, name conflow.ID, value interface{}) error {
-	{{ if filterInputs (filterParams .Schema.GetProperties) -}}
+	{{ if filterInputs (filterParams .Schema.GetParameters) -}}
 	b := block.(*{{ .NameSelector }}{{ .Name }})
 	switch name {
-	{{ range $name, $property := filterInputs (filterParams .Schema.GetProperties) -}}
+	{{ range $name, $property := filterInputs (filterParams .Schema.GetParameters) -}}
 	case "{{ $name }}":
-		{{ assignValue $property "value" (printf "b.%s" (getPropertyName $name)) }}
+		{{ assignValue $property "value" (printf "b.%s" (getFieldName $name)) }}
 	{{ end -}}
 	}
 	return nil
@@ -110,15 +110,15 @@ func (i {{ .Name }}Interpreter) SetParam(block conflow.Block, name conflow.ID, v
 }
 
 func (i {{ .Name }}Interpreter) SetBlock(block conflow.Block, name conflow.ID, value interface{}) error {
-	{{ if filterInputs (filterBlocks .Schema.GetProperties) -}}
+	{{ if filterInputs (filterBlocks .Schema.GetParameters) -}}
 	b := block.(*{{ $root.NameSelector }}{{ $root.Name }})
 	switch name {
-	{{ range $name, $property := filterInputs (filterBlocks .Schema.GetProperties) -}}
+	{{ range $name, $property := filterInputs (filterBlocks .Schema.GetParameters) -}}
 	case "{{ $name }}":
 		{{ if isArray $property -}}
-		b.{{ getPropertyName $name }} = append(b.{{ getPropertyName $name }}, value.({{ getType $property.GetItems }}))
+		b.{{ getFieldName $name }} = append(b.{{ getFieldName $name }}, value.({{ getType $property.GetItems }}))
 		{{ else -}}
-		b.{{ getPropertyName $name }} = value.({{ getType $property }})
+		b.{{ getFieldName $name }} = value.({{ getType $property }})
 		{{ end -}}
 	{{ end -}}
 	}

--- a/conflow/block/generator/parse_test.go
+++ b/conflow/block/generator/parse_test.go
@@ -54,7 +54,7 @@ var _ = Describe("ParseStruct", func() {
 					Description: "It is a test struct",
 				},
 				Name: "Foo",
-				Properties: map[string]schema.Schema{
+				Parameters: map[string]schema.Schema{
 					"id": &schema.String{
 						Metadata: schema.Metadata{
 							Annotations: expectedIDAnnotations,
@@ -87,57 +87,57 @@ var _ = Describe("ParseStruct", func() {
 		Entry("valid id field", "", func(schema.Schema) {}),
 
 		Entry("string field", "field string", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.String{}
+			s.(*schema.Object).Parameters["field"] = &schema.String{}
 		}),
 
 		Entry("bool field", "field bool", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Boolean{}
+			s.(*schema.Object).Parameters["field"] = &schema.Boolean{}
 		}),
 
 		Entry("integer field", "field int64", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Integer{}
+			s.(*schema.Object).Parameters["field"] = &schema.Integer{}
 		}),
 
 		Entry("number field", "field float64", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Number{}
+			s.(*schema.Object).Parameters["field"] = &schema.Number{}
 		}),
 
 		Entry("time duration field", "field time.Duration", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.TimeDuration{}
+			s.(*schema.Object).Parameters["field"] = &schema.TimeDuration{}
 		}),
 
 		Entry("string array", "field []string", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Array{
+			s.(*schema.Object).Parameters["field"] = &schema.Array{
 				Items: &schema.String{},
 			}
 		}),
 
 		Entry("bool array", "field []bool", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Array{
+			s.(*schema.Object).Parameters["field"] = &schema.Array{
 				Items: &schema.Boolean{},
 			}
 		}),
 
 		Entry("integer array", "field []int64", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Array{
+			s.(*schema.Object).Parameters["field"] = &schema.Array{
 				Items: &schema.Integer{},
 			}
 		}),
 
 		Entry("number array", "field []float64", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Array{
+			s.(*schema.Object).Parameters["field"] = &schema.Array{
 				Items: &schema.Number{},
 			}
 		}),
 
 		Entry("time duration array", "field []time.Duration", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Array{
+			s.(*schema.Object).Parameters["field"] = &schema.Array{
 				Items: &schema.TimeDuration{},
 			}
 		}),
 
 		Entry("arrays of arrays", "field [][]string", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Array{
+			s.(*schema.Object).Parameters["field"] = &schema.Array{
 				Items: &schema.Array{
 					Items: &schema.String{},
 				},
@@ -145,37 +145,37 @@ var _ = Describe("ParseStruct", func() {
 		}),
 
 		Entry("string map", "field map[string]string", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Map{
+			s.(*schema.Object).Parameters["field"] = &schema.Map{
 				AdditionalProperties: &schema.String{},
 			}
 		}),
 
 		Entry("integer map", "field map[string]int64", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Map{
+			s.(*schema.Object).Parameters["field"] = &schema.Map{
 				AdditionalProperties: &schema.Integer{},
 			}
 		}),
 
 		Entry("number map", "field map[string]float64", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Map{
+			s.(*schema.Object).Parameters["field"] = &schema.Map{
 				AdditionalProperties: &schema.Number{},
 			}
 		}),
 
 		Entry("boolean map", "field map[string]bool", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Map{
+			s.(*schema.Object).Parameters["field"] = &schema.Map{
 				AdditionalProperties: &schema.Boolean{},
 			}
 		}),
 
 		Entry("time duration map", "field map[string]time.Duration", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Map{
+			s.(*schema.Object).Parameters["field"] = &schema.Map{
 				AdditionalProperties: &schema.TimeDuration{},
 			}
 		}),
 
 		Entry("maps of maps", "field map[string]map[string]string", func(s schema.Schema) {
-			s.(*schema.Object).Properties["field"] = &schema.Map{
+			s.(*schema.Object).Parameters["field"] = &schema.Map{
 				AdditionalProperties: &schema.Map{
 					AdditionalProperties: &schema.String{},
 				},
@@ -186,10 +186,9 @@ var _ = Describe("ParseStruct", func() {
 			"valid json field name should be used as property name",
 			"field string `json:\"custom_field_name\"`",
 			func(s schema.Schema) {
-				s.(*schema.Object).Properties["custom_field_name"] = &schema.String{}
-				s.(*schema.Object).PropertyNames = map[string]string{
-					"custom_field_name": "field",
-				}
+				s.(*schema.Object).Parameters["field"] = &schema.String{}
+				s.(*schema.Object).JSONPropertyNames = map[string]string{"field": "custom_field_name"}
+				s.(*schema.Object).FieldNames = map[string]string{"custom_field_name": "field"}
 			},
 		),
 
@@ -197,18 +196,8 @@ var _ = Describe("ParseStruct", func() {
 			"valid @name directive should be used as property name",
 			"// @name \"custom_field_name\"\nfield string",
 			func(s schema.Schema) {
-				s.(*schema.Object).Properties["custom_field_name"] = &schema.String{}
-				s.(*schema.Object).PropertyNames = map[string]string{
-					"custom_field_name": "field",
-				}
-			},
-		),
-
-		Entry(
-			"invalid json field name should not be used as property name",
-			"field string `json:\"customFieldName\"`",
-			func(s schema.Schema) {
-				s.(*schema.Object).Properties["field"] = &schema.String{}
+				s.(*schema.Object).Parameters["custom_field_name"] = &schema.String{}
+				s.(*schema.Object).JSONPropertyNames = map[string]string{"custom_field_name": "field"}
 			},
 		),
 
@@ -216,37 +205,14 @@ var _ = Describe("ParseStruct", func() {
 			"valid property name should be generated",
 			"fieldName string",
 			func(s schema.Schema) {
-				s.(*schema.Object).Properties["field_name"] = &schema.String{}
-				s.(*schema.Object).PropertyNames = map[string]string{
-					"field_name": "fieldName",
-				}
+				s.(*schema.Object).Parameters["field_name"] = &schema.String{}
+				s.(*schema.Object).JSONPropertyNames = map[string]string{"field_name": "fieldName"}
 			},
 		),
 
 		Entry(
 			"field should be ignored if a JSON annotation ignores it",
 			"fieldName string `json:\"-\"`",
-			func(s schema.Schema) {
-			},
-		),
-
-		Entry(
-			"JSON ignore should work on an unsupported field type",
-			"fieldName int8 `json:\"-\"`",
-			func(s schema.Schema) {
-			},
-		),
-
-		Entry(
-			"JSON ignore should work on an unsupported array field type",
-			"fieldName []int8 `json:\"-\"`",
-			func(s schema.Schema) {
-			},
-		),
-
-		Entry(
-			"JSON ignore should work on an unsupported map field type",
-			"fieldName map[int8]int8 `json:\"-\"`",
 			func(s schema.Schema) {
 			},
 		),
@@ -316,7 +282,7 @@ var _ = Describe("ParseStruct", func() {
 				Expect(parseErr).ToNot(HaveOccurred())
 				Expect(resultStruct.Schema).To(Equal(&schema.Object{
 					Name: "Foo",
-					Properties: map[string]schema.Schema{
+					Parameters: map[string]schema.Schema{
 						"id": &schema.String{
 							Metadata: schema.Metadata{
 								Annotations: expectedIDAnnotations,

--- a/conflow/block/helper.go
+++ b/conflow/block/helper.go
@@ -26,11 +26,11 @@ func IsBlockSchema(s schema.Schema) bool {
 }
 
 func getNameSchemaForChildBlock(s *schema.Object, node conflow.BlockNode) (conflow.ID, schema.Schema) {
-	if p, ok := s.Properties[string(node.ID())]; ok {
+	if p, ok := s.Parameters[string(node.ID())]; ok {
 		return node.ID(), p
 	}
 
-	if p, ok := s.Properties[string(node.ParameterName())]; ok {
+	if p, ok := s.Parameters[string(node.ParameterName())]; ok {
 		return node.ParameterName(), p
 	}
 

--- a/conflow/block/node.go
+++ b/conflow/block/node.go
@@ -123,7 +123,7 @@ func (n *Node) SetSchema(s schema.Schema) {
 }
 
 func (n *Node) GetPropertySchema(name conflow.ID) (schema.Schema, bool) {
-	s, ok := n.schema.Properties[string(name)]
+	s, ok := n.schema.Parameters[string(name)]
 	if ok {
 		return s, true
 	}
@@ -176,7 +176,7 @@ func (n *Node) StaticCheck(ctx interface{}) parsley.Error {
 	for _, child := range n.Children() {
 		switch c := child.(type) {
 		case conflow.BlockNode:
-			property, exists := n.schema.Properties[string(c.ParameterName())]
+			property, exists := n.schema.Parameters[string(c.ParameterName())]
 
 			if !exists && c.ParameterName() != c.BlockType() {
 				return parsley.NewErrorf(c.Pos(), "%q parameter does not exist", c.ParameterName())
@@ -189,7 +189,7 @@ func (n *Node) StaticCheck(ctx interface{}) parsley.Error {
 				}
 			}
 		case conflow.ParameterNode:
-			property, exists := n.schema.Properties[string(c.Name())]
+			property, exists := n.schema.Parameters[string(c.Name())]
 
 			switch {
 			case exists && c.IsDeclaration() && property.GetAnnotation(conflow.AnnotationUserDefined) != "true":
@@ -223,7 +223,7 @@ func (n *Node) StaticCheck(ctx interface{}) parsley.Error {
 			return false
 		}()
 		if !found {
-			if IsBlockSchema(n.schema.Properties[required]) {
+			if IsBlockSchema(n.schema.Parameters[required]) {
 				return parsley.NewError(n.Pos(), fmt.Errorf("%q block is required", required))
 			} else {
 				return parsley.NewError(n.Pos(), fmt.Errorf("%q parameter is required", required))

--- a/conflow/block/transform.go
+++ b/conflow/block/transform.go
@@ -100,7 +100,7 @@ func TransformNode(ctx interface{}, node parsley.Node, interpreter conflow.Block
 				false,
 				nil,
 			)
-			paramNode.SetSchema(interpreter.Schema().(*schema.Object).Properties[string(valueParamName)])
+			paramNode.SetSchema(interpreter.Schema().(*schema.Object).Parameters[string(valueParamName)])
 
 			var deps conflow.Dependencies
 			children, deps, err = dependency.NewResolver(idNode.ID(), paramNode).Resolve()
@@ -200,9 +200,9 @@ func TransformChildren(
 			}
 			blockNode := res.(conflow.BlockNode)
 
-			if blockSchema, ok := interpreter.Schema().(*schema.Object).Properties[string(blockNode.ID())]; ok {
+			if blockSchema, ok := interpreter.Schema().(*schema.Object).Parameters[string(blockNode.ID())]; ok {
 				blockNode.SetSchema(blockSchema)
-			} else if blockSchema, ok := interpreter.Schema().(*schema.Object).Properties[string(blockNode.ParameterName())]; ok {
+			} else if blockSchema, ok := interpreter.Schema().(*schema.Object).Parameters[string(blockNode.ParameterName())]; ok {
 				blockNode.SetSchema(blockSchema)
 			}
 
@@ -219,7 +219,7 @@ func TransformChildren(
 				return nil, nil, err
 			}
 
-			if paramSchema, ok := interpreter.Schema().(*schema.Object).Properties[string(paramNode.Name())]; ok {
+			if paramSchema, ok := interpreter.Schema().(*schema.Object).Parameters[string(paramNode.Name())]; ok {
 				paramNode.SetSchema(paramSchema)
 			}
 
@@ -243,7 +243,7 @@ func getModuleSchema(children []conflow.Node, interpreter conflow.BlockInterpret
 			}
 
 			if util.BoolValue(config.Input) || util.BoolValue(config.Output) {
-				if _, exists := interpreter.Schema().(schema.ObjectKind).GetProperties()[string(paramNode.Name())]; exists {
+				if _, exists := interpreter.Schema().(schema.ObjectKind).GetParameters()[string(paramNode.Name())]; exists {
 					return nil, parsley.NewErrorf(c.Pos(), "%q parameter already exists.", paramNode.Name())
 				}
 			} else {
@@ -254,8 +254,8 @@ func getModuleSchema(children []conflow.Node, interpreter conflow.BlockInterpret
 				s = interpreter.Schema().Copy()
 			}
 			o := s.(*schema.Object)
-			if o.Properties == nil {
-				o.Properties = map[string]schema.Schema{}
+			if o.Parameters == nil {
+				o.Parameters = map[string]schema.Schema{}
 			}
 
 			switch {
@@ -271,7 +271,7 @@ func getModuleSchema(children []conflow.Node, interpreter conflow.BlockInterpret
 				config.Schema.(schema.MetadataAccessor).SetAnnotation(conflow.AnnotationEvalStage, conflow.EvalStageInit.String())
 				config.Schema.(schema.MetadataAccessor).SetAnnotation(conflow.AnnotationUserDefined, "true")
 
-				o.Properties[string(paramNode.Name())] = config.Schema
+				o.Parameters[string(paramNode.Name())] = config.Schema
 				paramNode.SetSchema(config.Schema)
 			case util.BoolValue(config.Output):
 				if config.Schema == nil {
@@ -282,7 +282,7 @@ func getModuleSchema(children []conflow.Node, interpreter conflow.BlockInterpret
 				config.Schema.(schema.MetadataAccessor).SetAnnotation(conflow.AnnotationUserDefined, "true")
 				config.Schema.(schema.MetadataAccessor).SetReadOnly(true)
 
-				o.Properties[string(paramNode.Name())] = config.Schema
+				o.Parameters[string(paramNode.Name())] = config.Schema
 				paramNode.SetSchema(config.Schema)
 			}
 		}

--- a/conflow/eval.go
+++ b/conflow/eval.go
@@ -31,8 +31,8 @@ func Evaluate(
 	}
 
 	o := node.Interpreter().Schema().(schema.ObjectKind)
-	for paramName, param := range o.GetProperties() {
-		if param.GetAnnotation(AnnotationUserDefined) == "true" && o.IsPropertyRequired(paramName) {
+	for paramName, param := range o.GetParameters() {
+		if param.GetAnnotation(AnnotationUserDefined) == "true" && o.IsParameterRequired(paramName) {
 			if _, isDefined := inputParams[ID(paramName)]; !isDefined {
 				return nil, fmt.Errorf("%q input parameter must be defined", paramName)
 			}
@@ -40,7 +40,7 @@ func Evaluate(
 	}
 
 	for k, v := range inputParams {
-		property := o.GetProperties()[string(k)]
+		property := o.GetParameters()[string(k)]
 		if property != nil &&
 			property.GetAnnotation(AnnotationUserDefined) == "true" &&
 			!property.GetReadOnly() {

--- a/conflow/function.go
+++ b/conflow/function.go
@@ -13,7 +13,7 @@ import (
 )
 
 // FunctionNameRegExpPattern defines a valid function name
-const FunctionNameRegExpPattern = IDRegExpPattern + "(?:\\." + IDRegExpPattern + ")?"
+const FunctionNameRegExpPattern = schema.NameRegExpPattern + "(?:\\." + schema.NameRegExpPattern + ")?"
 
 // FunctionNode is the AST node for a function
 //counterfeiter:generate . FunctionNode

--- a/conflow/generator/write_file.go
+++ b/conflow/generator/write_file.go
@@ -17,11 +17,11 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/conflowio/conflow/conflow/generator/parser"
+	"github.com/conflowio/conflow/internal/utils"
 )
 
 func writeFile(dir, name string, content []byte) error {
-	conflowFile := parser.ToSnakeCase(name) + ".cf.go"
+	conflowFile := utils.ToSnakeCase(name) + ".cf.go"
 	filepath := path.Join(dir, conflowFile)
 
 	info, direrr := os.Stat(dir)

--- a/conflow/id.go
+++ b/conflow/id.go
@@ -6,16 +6,6 @@
 
 package conflow
 
-import (
-	"regexp"
-)
-
-// IDRegExpPattern is the regular expression for a valid identifier
-const IDRegExpPattern = "[a-z][a-z0-9]*(?:_[a-z0-9]+)*"
-
-// IDRegExp is a compiled regular expression object for a valid identifier
-var IDRegExp = regexp.MustCompile("^" + IDRegExpPattern + "$")
-
 // Keywords are reserved strings and may not be used as identifiers.
 var Keywords = []string{
 	"map",

--- a/conflow/schema/directives/block.cf.go
+++ b/conflow/schema/directives/block.cf.go
@@ -19,8 +19,9 @@ func (i BlockInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Description: "It is the directive for marking structs as conflow blocks",
 			},
-			Name: "Block",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"eval_stage": "EvalStage", "path": "Path"},
+			Name:              "Block",
+			Parameters: map[string]schema.Schema{
 				"eval_stage": &schema.String{
 					Enum: []string{"ignore", "init", "parse", "resolve"},
 				},
@@ -33,7 +34,6 @@ func (i BlockInterpreter) Schema() schema.Schema {
 				},
 				"path": &schema.String{},
 			},
-			PropertyNames: map[string]string{"eval_stage": "EvalStage", "path": "Path"},
 		}
 	}
 	return i.s

--- a/conflow/schema/directives/const.cf.go
+++ b/conflow/schema/directives/const.cf.go
@@ -17,7 +17,7 @@ func (i ConstInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Const",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/default.cf.go
+++ b/conflow/schema/directives/default.cf.go
@@ -17,7 +17,7 @@ func (i DefaultInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Default",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/dependency.cf.go
+++ b/conflow/schema/directives/dependency.cf.go
@@ -16,8 +16,9 @@ type DependencyInterpreter struct {
 func (i DependencyInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "Dependency",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"name": "Name"},
+			Name:              "Dependency",
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -31,7 +32,6 @@ func (i DependencyInterpreter) Schema() schema.Schema {
 					},
 				},
 			},
-			PropertyNames: map[string]string{"name": "Name"},
 		}
 	}
 	return i.s

--- a/conflow/schema/directives/deprecated.cf.go
+++ b/conflow/schema/directives/deprecated.cf.go
@@ -17,7 +17,7 @@ func (i DeprecatedInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Deprecated",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/enum.cf.go
+++ b/conflow/schema/directives/enum.cf.go
@@ -17,7 +17,7 @@ func (i EnumInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Enum",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/eval_stage.cf.go
+++ b/conflow/schema/directives/eval_stage.cf.go
@@ -17,7 +17,7 @@ func (i EvalStageInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "EvalStage",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/examples.cf.go
+++ b/conflow/schema/directives/examples.cf.go
@@ -17,7 +17,7 @@ func (i ExamplesInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Examples",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/exclusive_maximum.cf.go
+++ b/conflow/schema/directives/exclusive_maximum.cf.go
@@ -17,7 +17,7 @@ func (i ExclusiveMaximumInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "ExclusiveMaximum",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/exclusive_minimum.cf.go
+++ b/conflow/schema/directives/exclusive_minimum.cf.go
@@ -17,7 +17,7 @@ func (i ExclusiveMinimumInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "ExclusiveMinimum",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/format.cf.go
+++ b/conflow/schema/directives/format.cf.go
@@ -17,7 +17,7 @@ func (i FormatInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Format",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/function.cf.go
+++ b/conflow/schema/directives/function.cf.go
@@ -19,8 +19,9 @@ func (i FunctionInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Description: "It is the directive for marking functions as conflow functions",
 			},
-			Name: "Function",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"path": "Path"},
+			Name:              "Function",
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -30,7 +31,6 @@ func (i FunctionInterpreter) Schema() schema.Schema {
 				},
 				"path": &schema.String{},
 			},
-			PropertyNames: map[string]string{"path": "Path"},
 		}
 	}
 	return i.s

--- a/conflow/schema/directives/generated.cf.go
+++ b/conflow/schema/directives/generated.cf.go
@@ -17,7 +17,7 @@ func (i GeneratedInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Generated",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/id.cf.go
+++ b/conflow/schema/directives/id.cf.go
@@ -17,7 +17,7 @@ func (i IDInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "ID",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/ignore.cf.go
+++ b/conflow/schema/directives/ignore.cf.go
@@ -17,7 +17,7 @@ func (i IgnoreInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Ignore",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/max_items.cf.go
+++ b/conflow/schema/directives/max_items.cf.go
@@ -17,7 +17,7 @@ func (i MaxItemsInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "MaxItems",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/max_length.cf.go
+++ b/conflow/schema/directives/max_length.cf.go
@@ -17,7 +17,7 @@ func (i MaxLengthInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "MaxLength",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/maximum.cf.go
+++ b/conflow/schema/directives/maximum.cf.go
@@ -17,7 +17,7 @@ func (i MaximumInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Maximum",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/min_items.cf.go
+++ b/conflow/schema/directives/min_items.cf.go
@@ -17,7 +17,7 @@ func (i MinItemsInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "MinItems",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/min_length.cf.go
+++ b/conflow/schema/directives/min_length.cf.go
@@ -17,7 +17,7 @@ func (i MinLengthInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "MinLength",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/minimum.cf.go
+++ b/conflow/schema/directives/minimum.cf.go
@@ -17,7 +17,7 @@ func (i MinimumInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Minimum",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/multiple_of.cf.go
+++ b/conflow/schema/directives/multiple_of.cf.go
@@ -17,7 +17,7 @@ func (i MultipleOfInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "MultipleOf",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/name.cf.go
+++ b/conflow/schema/directives/name.cf.go
@@ -16,8 +16,9 @@ type NameInterpreter struct {
 func (i NameInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "Name",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"value": "Value"},
+			Name:              "Name",
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -31,8 +32,7 @@ func (i NameInterpreter) Schema() schema.Schema {
 					},
 				},
 			},
-			PropertyNames: map[string]string{"value": "Value"},
-			Required:      []string{"value"},
+			Required: []string{"value"},
 		}
 	}
 	return i.s

--- a/conflow/schema/directives/pattern.cf.go
+++ b/conflow/schema/directives/pattern.cf.go
@@ -17,7 +17,7 @@ func (i PatternInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Pattern",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/read_only.cf.go
+++ b/conflow/schema/directives/read_only.cf.go
@@ -17,7 +17,7 @@ func (i ReadOnlyInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "ReadOnly",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/required.cf.go
+++ b/conflow/schema/directives/required.cf.go
@@ -17,7 +17,7 @@ func (i RequiredInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Required",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/result_type.cf.go
+++ b/conflow/schema/directives/result_type.cf.go
@@ -17,7 +17,7 @@ func (i ResultTypeInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "ResultType",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/title.cf.go
+++ b/conflow/schema/directives/title.cf.go
@@ -17,7 +17,7 @@ func (i TitleInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Title",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/types.cf.go
+++ b/conflow/schema/directives/types.cf.go
@@ -17,7 +17,7 @@ func (i TypesInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Types",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/unique_items.cf.go
+++ b/conflow/schema/directives/unique_items.cf.go
@@ -17,7 +17,7 @@ func (i UniqueItemsInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "UniqueItems",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/value.cf.go
+++ b/conflow/schema/directives/value.cf.go
@@ -17,7 +17,7 @@ func (i ValueInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Value",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/directives/write_only.cf.go
+++ b/conflow/schema/directives/write_only.cf.go
@@ -17,7 +17,7 @@ func (i WriteOnlyInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "WriteOnly",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/conflow/schema/schema.go
+++ b/conflow/schema/schema.go
@@ -11,10 +11,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"regexp"
 	"time"
 
 	"github.com/tidwall/gjson"
 )
+
+// NameRegExpPattern is the regular expression for a valid identifier
+const NameRegExpPattern = "[a-z][a-z0-9]*(?:_[a-z0-9]+)*"
+
+// NameRegExp is a compiled regular expression object for a valid identifier
+var NameRegExp = regexp.MustCompile("^" + NameRegExpPattern + "$")
+
+var fieldNameRegexp = regexp.MustCompile("^[_a-zA-Z][_a-zA-Z0-9]*$")
 
 type Schema interface {
 	AssignValue(imports map[string]string, valueName, resultName string) string
@@ -48,11 +57,12 @@ func IsArray(s Schema) bool {
 }
 
 type ObjectKind interface {
-	GetProperties() map[string]Schema
-	IsPropertyRequired(name string) bool
+	GetFieldName(string) string
+	GetJSONPropertyName(string) string
+	GetParameters() map[string]Schema
+	IsParameterRequired(name string) bool
 	GetName() string
 	GetRequired() []string
-	GetPropertyNames() map[string]string
 }
 
 func IsObject(s Schema) bool {

--- a/conflow/schema/schema_test.go
+++ b/conflow/schema/schema_test.go
@@ -12,10 +12,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/conflowio/conflow/conflow/schema"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
+	"github.com/conflowio/conflow/conflow/schema"
 )
 
 var _ = Describe("Metadata", func() {
@@ -193,7 +194,7 @@ var _ = Describe("Schema", func() {
 			"object",
 			&schema.Object{
 				Metadata: schema.Metadata{Description: "foo"},
-				Properties: map[string]schema.Schema{
+				Parameters: map[string]schema.Schema{
 					"foo": &schema.Integer{},
 				},
 			},

--- a/directives/array.cf.go
+++ b/directives/array.cf.go
@@ -19,8 +19,10 @@ func (i ArrayInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
-			Name: "Array",
-			Properties: map[string]schema.Schema{
+			FieldNames:        map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "items": "Items", "maxItems": "MaxItems", "minItems": "MinItems", "pointer": "Pointer", "readOnly": "ReadOnly", "title": "Title", "uniqueItems": "UniqueItems", "writeOnly": "WriteOnly"},
+			JSONPropertyNames: map[string]string{"max_items": "maxItems", "min_items": "minItems", "read_only": "readOnly", "unique_items": "uniqueItems", "write_only": "writeOnly"},
+			Name:              "Array",
+			Parameters: map[string]schema.Schema{
 				"annotations": &schema.Map{
 					AdditionalProperties: &schema.String{},
 				},
@@ -55,8 +57,7 @@ func (i ArrayInterpreter) Schema() schema.Schema {
 				"unique_items": &schema.Boolean{},
 				"write_only":   &schema.Boolean{},
 			},
-			PropertyNames: map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "items": "Items", "max_items": "MaxItems", "min_items": "MinItems", "pointer": "Pointer", "read_only": "ReadOnly", "title": "Title", "unique_items": "UniqueItems", "write_only": "WriteOnly"},
-			Required:      []string{"items"},
+			Required: []string{"items"},
 		}
 	}
 	return i.s

--- a/directives/boolean.cf.go
+++ b/directives/boolean.cf.go
@@ -19,8 +19,10 @@ func (i BooleanInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
-			Name: "Boolean",
-			Properties: map[string]schema.Schema{
+			FieldNames:        map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "pointer": "Pointer", "readOnly": "ReadOnly", "title": "Title", "writeOnly": "WriteOnly"},
+			JSONPropertyNames: map[string]string{"read_only": "readOnly", "write_only": "writeOnly"},
+			Name:              "Boolean",
+			Parameters: map[string]schema.Schema{
 				"annotations": &schema.Map{
 					AdditionalProperties: &schema.String{},
 				},
@@ -47,7 +49,6 @@ func (i BooleanInterpreter) Schema() schema.Schema {
 				"title":      &schema.String{},
 				"write_only": &schema.Boolean{},
 			},
-			PropertyNames: map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "pointer": "Pointer", "read_only": "ReadOnly", "title": "Title", "write_only": "WriteOnly"},
 		}
 	}
 	return i.s

--- a/directives/bug.cf.go
+++ b/directives/bug.cf.go
@@ -20,7 +20,7 @@ func (i BugInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "ignore"},
 			},
 			Name: "Bug",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"description": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/value": "true"},

--- a/directives/deprecated.cf.go
+++ b/directives/deprecated.cf.go
@@ -20,7 +20,7 @@ func (i DeprecatedInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "ignore"},
 			},
 			Name: "Deprecated",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"description": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/value": "true"},

--- a/directives/doc.cf.go
+++ b/directives/doc.cf.go
@@ -20,7 +20,7 @@ func (i DocInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "ignore"},
 			},
 			Name: "Doc",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"description": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/value": "true"},

--- a/directives/input.cf.go
+++ b/directives/input.cf.go
@@ -20,7 +20,7 @@ func (i InputInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
 			Name: "Input",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/directives/integer.cf.go
+++ b/directives/integer.cf.go
@@ -19,8 +19,10 @@ func (i IntegerInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
-			Name: "Integer",
-			Properties: map[string]schema.Schema{
+			FieldNames:        map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "exclusiveMaximum": "ExclusiveMaximum", "exclusiveMinimum": "ExclusiveMinimum", "maximum": "Maximum", "minimum": "Minimum", "multipleOf": "MultipleOf", "pointer": "Pointer", "readOnly": "ReadOnly", "title": "Title", "writeOnly": "WriteOnly"},
+			JSONPropertyNames: map[string]string{"exclusive_maximum": "exclusiveMaximum", "exclusive_minimum": "exclusiveMinimum", "multiple_of": "multipleOf", "read_only": "readOnly", "write_only": "writeOnly"},
+			Name:              "Integer",
+			Parameters: map[string]schema.Schema{
 				"annotations": &schema.Map{
 					AdditionalProperties: &schema.String{},
 				},
@@ -72,7 +74,6 @@ func (i IntegerInterpreter) Schema() schema.Schema {
 				"title":      &schema.String{},
 				"write_only": &schema.Boolean{},
 			},
-			PropertyNames: map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "exclusive_maximum": "ExclusiveMaximum", "exclusive_minimum": "ExclusiveMinimum", "maximum": "Maximum", "minimum": "Minimum", "multiple_of": "MultipleOf", "pointer": "Pointer", "read_only": "ReadOnly", "title": "Title", "write_only": "WriteOnly"},
 		}
 	}
 	return i.s

--- a/directives/map.cf.go
+++ b/directives/map.cf.go
@@ -19,8 +19,10 @@ func (i MapInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
-			Name: "Map",
-			Properties: map[string]schema.Schema{
+			FieldNames:        map[string]string{"additionalProperties": "AdditionalProperties", "annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "pointer": "Pointer", "readOnly": "ReadOnly", "title": "Title", "writeOnly": "WriteOnly"},
+			JSONPropertyNames: map[string]string{"additional_properties": "additionalProperties", "read_only": "readOnly", "write_only": "writeOnly"},
+			Name:              "Map",
+			Parameters: map[string]schema.Schema{
 				"additional_properties": &schema.Reference{
 					Ref: "http://conflow.schema/github.com/conflowio/conflow/conflow/schema.Schema",
 				},
@@ -48,8 +50,7 @@ func (i MapInterpreter) Schema() schema.Schema {
 				"title":      &schema.String{},
 				"write_only": &schema.Boolean{},
 			},
-			PropertyNames: map[string]string{"additional_properties": "AdditionalProperties", "annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "pointer": "Pointer", "read_only": "ReadOnly", "title": "Title", "write_only": "WriteOnly"},
-			Required:      []string{"additional_properties"},
+			Required: []string{"additional_properties"},
 		}
 	}
 	return i.s

--- a/directives/number.cf.go
+++ b/directives/number.cf.go
@@ -19,8 +19,10 @@ func (i NumberInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
-			Name: "Number",
-			Properties: map[string]schema.Schema{
+			FieldNames:        map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "exclusiveMaximum": "ExclusiveMaximum", "exclusiveMinimum": "ExclusiveMinimum", "maximum": "Maximum", "minimum": "Minimum", "multipleOf": "MultipleOf", "pointer": "Pointer", "readOnly": "ReadOnly", "title": "Title", "writeOnly": "WriteOnly"},
+			JSONPropertyNames: map[string]string{"exclusive_maximum": "exclusiveMaximum", "exclusive_minimum": "exclusiveMinimum", "multiple_of": "multipleOf", "read_only": "readOnly", "write_only": "writeOnly"},
+			Name:              "Number",
+			Parameters: map[string]schema.Schema{
 				"annotations": &schema.Map{
 					AdditionalProperties: &schema.String{},
 				},
@@ -72,7 +74,6 @@ func (i NumberInterpreter) Schema() schema.Schema {
 				"title":      &schema.String{},
 				"write_only": &schema.Boolean{},
 			},
-			PropertyNames: map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "exclusive_maximum": "ExclusiveMaximum", "exclusive_minimum": "ExclusiveMinimum", "maximum": "Maximum", "minimum": "Minimum", "multiple_of": "MultipleOf", "pointer": "Pointer", "read_only": "ReadOnly", "title": "Title", "write_only": "WriteOnly"},
 		}
 	}
 	return i.s

--- a/directives/output.cf.go
+++ b/directives/output.cf.go
@@ -20,7 +20,7 @@ func (i OutputInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
 			Name: "Output",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/directives/retry.cf.go
+++ b/directives/retry.cf.go
@@ -20,7 +20,7 @@ func (i RetryInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "init"},
 			},
 			Name: "Retry",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/directives/run.cf.go
+++ b/directives/run.cf.go
@@ -20,7 +20,7 @@ func (i RunInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "init"},
 			},
 			Name: "Run",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/directives/skip.cf.go
+++ b/directives/skip.cf.go
@@ -20,7 +20,7 @@ func (i SkipInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "init"},
 			},
 			Name: "Skip",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/directives/string.cf.go
+++ b/directives/string.cf.go
@@ -19,8 +19,10 @@ func (i StringInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
-			Name: "String",
-			Properties: map[string]schema.Schema{
+			FieldNames:        map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "format": "Format", "maxLength": "MaxLength", "minLength": "MinLength", "pattern": "Pattern", "pointer": "Pointer", "readOnly": "ReadOnly", "title": "Title", "writeOnly": "WriteOnly"},
+			JSONPropertyNames: map[string]string{"max_length": "maxLength", "min_length": "minLength", "read_only": "readOnly", "write_only": "writeOnly"},
+			Name:              "String",
+			Parameters: map[string]schema.Schema{
 				"annotations": &schema.Map{
 					AdditionalProperties: &schema.String{},
 				},
@@ -57,7 +59,6 @@ func (i StringInterpreter) Schema() schema.Schema {
 				"title":      &schema.String{},
 				"write_only": &schema.Boolean{},
 			},
-			PropertyNames: map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "format": "Format", "max_length": "MaxLength", "min_length": "MinLength", "pattern": "Pattern", "pointer": "Pointer", "read_only": "ReadOnly", "title": "Title", "write_only": "WriteOnly"},
 		}
 	}
 	return i.s

--- a/directives/time.cf.go
+++ b/directives/time.cf.go
@@ -20,8 +20,10 @@ func (i TimeInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
-			Name: "Time",
-			Properties: map[string]schema.Schema{
+			FieldNames:        map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "pointer": "Pointer", "readOnly": "ReadOnly", "title": "Title", "writeOnly": "WriteOnly"},
+			JSONPropertyNames: map[string]string{"read_only": "readOnly", "write_only": "writeOnly"},
+			Name:              "Time",
+			Parameters: map[string]schema.Schema{
 				"annotations": &schema.Map{
 					AdditionalProperties: &schema.String{},
 				},
@@ -48,7 +50,6 @@ func (i TimeInterpreter) Schema() schema.Schema {
 				"title":      &schema.String{},
 				"write_only": &schema.Boolean{},
 			},
-			PropertyNames: map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "pointer": "Pointer", "read_only": "ReadOnly", "title": "Title", "write_only": "WriteOnly"},
 		}
 	}
 	return i.s

--- a/directives/time_duration.cf.go
+++ b/directives/time_duration.cf.go
@@ -20,8 +20,10 @@ func (i TimeDurationInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "parse"},
 			},
-			Name: "TimeDuration",
-			Properties: map[string]schema.Schema{
+			FieldNames:        map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "pointer": "Pointer", "readOnly": "ReadOnly", "title": "Title", "writeOnly": "WriteOnly"},
+			JSONPropertyNames: map[string]string{"read_only": "readOnly", "write_only": "writeOnly"},
+			Name:              "TimeDuration",
+			Parameters: map[string]schema.Schema{
 				"annotations": &schema.Map{
 					AdditionalProperties: &schema.String{},
 				},
@@ -48,7 +50,6 @@ func (i TimeDurationInterpreter) Schema() schema.Schema {
 				"title":      &schema.String{},
 				"write_only": &schema.Boolean{},
 			},
-			PropertyNames: map[string]string{"annotations": "Annotations", "const": "Const", "default": "Default", "deprecated": "Deprecated", "description": "Description", "enum": "Enum", "examples": "Examples", "pointer": "Pointer", "read_only": "ReadOnly", "title": "Title", "write_only": "WriteOnly"},
 		}
 	}
 	return i.s

--- a/directives/timeout.cf.go
+++ b/directives/timeout.cf.go
@@ -21,7 +21,7 @@ func (i TimeoutInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "init"},
 			},
 			Name: "Timeout",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"duration": &schema.TimeDuration{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/value": "true"},

--- a/directives/todo.cf.go
+++ b/directives/todo.cf.go
@@ -20,7 +20,7 @@ func (i TodoInterpreter) Schema() schema.Schema {
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "ignore"},
 			},
 			Name: "Todo",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"description": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/value": "true"},

--- a/directives/triggers.cf.go
+++ b/directives/triggers.cf.go
@@ -19,8 +19,9 @@ func (i TriggersInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Annotations: map[string]string{"block.conflow.io/eval_stage": "resolve"},
 			},
-			Name: "Triggers",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"block_ids": "blockIDs"},
+			Name:              "Triggers",
+			Parameters: map[string]schema.Schema{
 				"block_ids": &schema.Array{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/value": "true"},
@@ -35,8 +36,7 @@ func (i TriggersInterpreter) Schema() schema.Schema {
 					Format: "conflow.ID",
 				},
 			},
-			PropertyNames: map[string]string{"block_ids": "blockIDs"},
-			Required:      []string{"block_ids"},
+			Required: []string{"block_ids"},
 		}
 	}
 	return i.s

--- a/examples/benchmark/benchmark.cf.go
+++ b/examples/benchmark/benchmark.cf.go
@@ -18,7 +18,7 @@ func (i BenchmarkInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Benchmark",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"counter": &schema.Integer{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/eval_stage": "close"},

--- a/examples/benchmark/benchmark_run.cf.go
+++ b/examples/benchmark/benchmark_run.cf.go
@@ -17,7 +17,7 @@ func (i BenchmarkRunInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "BenchmarkRun",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"cnt": &schema.Integer{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/eval_stage": "close"},

--- a/examples/benchmark/main.cf.go
+++ b/examples/benchmark/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/common/it.cf.go
+++ b/examples/common/it.cf.go
@@ -17,7 +17,7 @@ func (i ItInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "It",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/common/iterator.cf.go
+++ b/examples/common/iterator.cf.go
@@ -17,7 +17,7 @@ func (i IteratorInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Iterator",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"count": &schema.Integer{},
 				"id": &schema.String{
 					Metadata: schema.Metadata{

--- a/examples/exec/main.cf.go
+++ b/examples/exec/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/helloworld/hello.cf.go
+++ b/examples/helloworld/hello.cf.go
@@ -20,7 +20,7 @@ func (i HelloInterpreter) Schema() schema.Schema {
 				Description: "It is capable to print some greetings",
 			},
 			Name: "Hello",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"greeting": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/eval_stage": "close"},

--- a/examples/helloworld/main.cf.go
+++ b/examples/helloworld/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/iterator/main.cf.go
+++ b/examples/iterator/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/licensify/file.cf.go
+++ b/examples/licensify/file.cf.go
@@ -17,7 +17,7 @@ func (i FileInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "File",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/licensify/glob.cf.go
+++ b/examples/licensify/glob.cf.go
@@ -17,7 +17,7 @@ func (i GlobInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Glob",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"exclude": &schema.Array{
 					Items: &schema.String{},
 				},

--- a/examples/licensify/licensify.cf.go
+++ b/examples/licensify/licensify.cf.go
@@ -17,7 +17,7 @@ func (i LicensifyInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Licensify",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/licensify/main.cf.go
+++ b/examples/licensify/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/multifile/main.cf.go
+++ b/examples/multifile/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/retry/fail.cf.go
+++ b/examples/retry/fail.cf.go
@@ -19,8 +19,9 @@ func (i FailInterpreter) Schema() schema.Schema {
 			Metadata: schema.Metadata{
 				Description: "It will error for the given tries",
 			},
-			Name: "Fail",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"tries_required": "triesRequired"},
+			Name:              "Fail",
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -36,8 +37,7 @@ func (i FailInterpreter) Schema() schema.Schema {
 				},
 				"tries_required": &schema.Integer{},
 			},
-			PropertyNames: map[string]string{"tries_required": "triesRequired"},
-			Required:      []string{"tries_required"},
+			Required: []string{"tries_required"},
 		}
 	}
 	return i.s

--- a/examples/retry/main.cf.go
+++ b/examples/retry/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/streams/main.cf.go
+++ b/examples/streams/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/ticker/main.cf.go
+++ b/examples/ticker/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/timeout/main.cf.go
+++ b/examples/timeout/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/examples/triggers/main.cf.go
+++ b/examples/triggers/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Opsidian Ltd.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+var reSnakeCaseFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+var reSnakeCaseAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+var reCamelCaseUnderscore = regexp.MustCompile("(^|_+)[a-zA-Z0-9]")
+
+func ToSnakeCase(name string) string {
+	name = reSnakeCaseFirstCap.ReplaceAllString(name, "${1}_${2}")
+	name = reSnakeCaseAllCap.ReplaceAllString(name, "${1}_${2}")
+	return strings.ToLower(name)
+}
+
+func ToCamelCase(name string) string {
+	return reCamelCaseUnderscore.ReplaceAllStringFunc(name, func(s string) string {
+		return strings.ToUpper(string(s[len(s)-1]))
+	})
+}

--- a/internal/utils/strings_test.go
+++ b/internal/utils/strings_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2017 Opsidian Ltd.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/conflowio/conflow/internal/utils"
+)
+
+var _ = Describe("ToSnakeCase", func() {
+	DescribeTable(
+		"It should convert string to snake_case",
+		func(input string, expected string) {
+			Expect(utils.ToSnakeCase(input)).To(Equal(expected))
+		},
+		Entry("lowercase", "foo", "foo"),
+		Entry("starts with capital", "Foo", "foo"),
+		Entry("capital in the middle", "fooBar", "foo_bar"),
+		Entry("multiple capitals", "FooBarBaz", "foo_bar_baz"),
+		Entry("capital at the end", "fooB", "foo_b"),
+		Entry("already snake_case", "foo_bar", "foo_bar"),
+		Entry("only capitals", "FOO", "foo"),
+		Entry("multiple capitals at the beginning", "FOOBar", "foo_bar"),
+		Entry("multiple capitals in the middle", "fooBARBaz", "foo_bar_baz"),
+		Entry("multiple capitals at the end", "fooBarBAZ", "foo_bar_baz"),
+		Entry("with numbers", "Foo9", "foo9"),
+		Entry("numbers after single capital letter", "I18nDict", "i18n_dict"),
+		Entry("single letter, single number", "F9", "f9"),
+	)
+})
+
+var _ = Describe("ToCamelCase", func() {
+	DescribeTable(
+		"It should convert string to camelCase",
+		func(input string, expected string) {
+			Expect(utils.ToCamelCase(input)).To(Equal(expected))
+		},
+		Entry("lowercase", "foo", "Foo"),
+		Entry("starts with capital", "Foo", "Foo"),
+		Entry("two parts with underscore", "foo_bar", "FooBar"),
+		Entry("two parts with multiple underscores", "foo__bar", "FooBar"),
+		Entry("three parts capitals", "foo_bar_baz", "FooBarBaz"),
+		Entry("single character in the second part", "foo_b", "FooB"),
+		Entry("single character in the first part", "f_bar", "FBar"),
+		Entry("already camelCase", "FooBar", "FooBar"),
+		Entry("only capitals", "FOO", "FOO"),
+		Entry("with numbers", "foo_9", "Foo9"),
+		Entry("numbers after first letter", "i18n_dict", "I18nDict"),
+		Entry("single letter, single number", "F9", "F9"),
+		Entry("abbreviation should be left as is", "YAMLDocument", "YAMLDocument"),
+	)
+})

--- a/internal/utils/utils_suite_test.go
+++ b/internal/utils/utils_suite_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2017 Opsidian Ltd.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/parsers/id.go
+++ b/parsers/id.go
@@ -13,6 +13,7 @@ import (
 	"github.com/conflowio/parsley/text"
 
 	"github.com/conflowio/conflow/conflow"
+	"github.com/conflowio/conflow/conflow/schema"
 )
 
 // ID parses an identifier:
@@ -42,7 +43,7 @@ func id(classifier rune) parser.Func {
 			}
 		}
 
-		if readerPos, match := tr.ReadRegexp(pos, conflow.IDRegExpPattern); match != nil {
+		if readerPos, match := tr.ReadRegexp(pos, schema.NameRegExpPattern); match != nil {
 			id := string(match)
 			if ctx.IsKeyword(id) {
 				return nil, data.EmptyIntSet, parsley.NewErrorf(pos, "%s is a reserved keyword", id)

--- a/test/block.cf.go
+++ b/test/block.cf.go
@@ -17,8 +17,9 @@ type BlockInterpreter struct {
 func (i BlockInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "Block",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"custom_field": "FieldCustomName", "field_array": "FieldArray", "field_bool": "FieldBool", "field_float": "FieldFloat", "field_int": "FieldInt", "field_map": "FieldMap", "field_string": "FieldString", "field_time_duration": "FieldTimeDuration", "id_field": "IDField", "testblock": "Blocks", "value": "Value"},
+			Name:              "Block",
+			Parameters: map[string]schema.Schema{
 				"custom_field": &schema.String{},
 				"field_array": &schema.Array{
 					Items: &schema.Untyped{},
@@ -52,7 +53,6 @@ func (i BlockInterpreter) Schema() schema.Schema {
 					},
 				},
 			},
-			PropertyNames: map[string]string{"custom_field": "FieldCustomName", "field_array": "FieldArray", "field_bool": "FieldBool", "field_float": "FieldFloat", "field_int": "FieldInt", "field_map": "FieldMap", "field_string": "FieldString", "field_time_duration": "FieldTimeDuration", "id_field": "IDField", "testblock": "Blocks", "value": "Value"},
 		}
 	}
 	return i.s

--- a/test/block.go
+++ b/test/block.go
@@ -90,7 +90,7 @@ func (b *Block) Compare(b2 *Block, input string) {
 func compareBlocks(b1, b2 conflow.Identifiable, interpreter conflow.BlockInterpreter, input string) {
 	Expect(b1.ID()).To(Equal(b2.ID()), "id does not match, input: %s", input)
 
-	for propertyName, p := range interpreter.Schema().(schema.ObjectKind).GetProperties() {
+	for propertyName, p := range interpreter.Schema().(schema.ObjectKind).GetParameters() {
 		if block.IsBlockSchema(p) {
 			continue
 		}

--- a/test/directive.cf.go
+++ b/test/directive.cf.go
@@ -17,8 +17,9 @@ type DirectiveInterpreter struct {
 func (i DirectiveInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "Directive",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"custom_field": "FieldCustomName", "field_array": "FieldArray", "field_bool": "FieldBool", "field_float": "FieldFloat", "field_int": "FieldInt", "field_map": "FieldMap", "field_string": "FieldString", "field_time_duration": "FieldTimeDuration", "id_field": "IDField", "testblock": "Blocks", "value": "Value"},
+			Name:              "Directive",
+			Parameters: map[string]schema.Schema{
 				"custom_field": &schema.String{},
 				"field_array": &schema.Array{
 					Items: &schema.Untyped{},
@@ -52,7 +53,6 @@ func (i DirectiveInterpreter) Schema() schema.Schema {
 					},
 				},
 			},
-			PropertyNames: map[string]string{"custom_field": "FieldCustomName", "field_array": "FieldArray", "field_bool": "FieldBool", "field_float": "FieldFloat", "field_int": "FieldInt", "field_map": "FieldMap", "field_string": "FieldString", "field_time_duration": "FieldTimeDuration", "id_field": "IDField", "testblock": "Blocks", "value": "Value"},
 		}
 	}
 	return i.s

--- a/test/fixtures/block.cf.go
+++ b/test/fixtures/block.cf.go
@@ -17,8 +17,9 @@ type BlockInterpreter struct {
 func (i BlockInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "Block",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"field_array": "FieldArray", "field_bool": "FieldBool", "field_float": "FieldFloat", "field_identifier": "FieldIdentifier", "field_integer": "FieldInteger", "field_interface": "FieldInterface", "field_map": "FieldMap", "field_number": "FieldNumber", "field_string": "FieldString", "field_string_array": "FieldStringArray", "field_time": "FieldTime", "field_time_duration": "FieldTimeDuration", "id_field": "IDField"},
+			Name:              "Block",
+			Parameters: map[string]schema.Schema{
 				"field_array": &schema.Array{
 					Items: &schema.Untyped{},
 				},
@@ -53,7 +54,6 @@ func (i BlockInterpreter) Schema() schema.Schema {
 					Format: "conflow.ID",
 				},
 			},
-			PropertyNames: map[string]string{"field_array": "FieldArray", "field_bool": "FieldBool", "field_float": "FieldFloat", "field_identifier": "FieldIdentifier", "field_integer": "FieldInteger", "field_interface": "FieldInterface", "field_map": "FieldMap", "field_number": "FieldNumber", "field_string": "FieldString", "field_string_array": "FieldStringArray", "field_time": "FieldTime", "field_time_duration": "FieldTimeDuration", "id_field": "IDField"},
 		}
 	}
 	return i.s

--- a/test/fixtures/block_generator.cf.go
+++ b/test/fixtures/block_generator.cf.go
@@ -17,7 +17,7 @@ func (i BlockGeneratorInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "BlockGenerator",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/test/fixtures/block_generator_result.cf.go
+++ b/test/fixtures/block_generator_result.cf.go
@@ -17,7 +17,7 @@ func (i BlockGeneratorResultInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "BlockGeneratorResult",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},

--- a/test/fixtures/block_no_fields.cf.go
+++ b/test/fixtures/block_no_fields.cf.go
@@ -16,8 +16,9 @@ type BlockNoFieldsInterpreter struct {
 func (i BlockNoFieldsInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockNoFields",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"id_field": "IDField"},
+			Name:              "BlockNoFields",
+			Parameters: map[string]schema.Schema{
 				"id_field": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -26,7 +27,6 @@ func (i BlockNoFieldsInterpreter) Schema() schema.Schema {
 					Format: "conflow.ID",
 				},
 			},
-			PropertyNames: map[string]string{"id_field": "IDField"},
 		}
 	}
 	return i.s

--- a/test/fixtures/block_required_field.cf.go
+++ b/test/fixtures/block_required_field.cf.go
@@ -16,8 +16,9 @@ type BlockRequiredFieldInterpreter struct {
 func (i BlockRequiredFieldInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockRequiredField",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"id_field": "IDField"},
+			Name:              "BlockRequiredField",
+			Parameters: map[string]schema.Schema{
 				"id_field": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -27,8 +28,7 @@ func (i BlockRequiredFieldInterpreter) Schema() schema.Schema {
 				},
 				"required": &schema.Untyped{},
 			},
-			PropertyNames: map[string]string{"id_field": "IDField"},
-			Required:      []string{"required"},
+			Required: []string{"required"},
 		}
 	}
 	return i.s

--- a/test/fixtures/block_value_field.cf.go
+++ b/test/fixtures/block_value_field.cf.go
@@ -16,8 +16,9 @@ type BlockValueFieldInterpreter struct {
 func (i BlockValueFieldInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockValueField",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"id_field": "IDField"},
+			Name:              "BlockValueField",
+			Parameters: map[string]schema.Schema{
 				"id_field": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -31,7 +32,6 @@ func (i BlockValueFieldInterpreter) Schema() schema.Schema {
 					},
 				},
 			},
-			PropertyNames: map[string]string{"id_field": "IDField"},
 		}
 	}
 	return i.s

--- a/test/fixtures/block_with_context.cf.go
+++ b/test/fixtures/block_with_context.cf.go
@@ -17,8 +17,9 @@ type BlockWithContextInterpreter struct {
 func (i BlockWithContextInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockWithContext",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"id_field": "IDField"},
+			Name:              "BlockWithContext",
+			Parameters: map[string]schema.Schema{
 				"id_field": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},
@@ -32,8 +33,7 @@ func (i BlockWithContextInterpreter) Schema() schema.Schema {
 					},
 				},
 			},
-			PropertyNames: map[string]string{"id_field": "IDField"},
-			Required:      []string{"timeout"},
+			Required: []string{"timeout"},
 		}
 	}
 	return i.s

--- a/test/fixtures/block_with_many_block.cf.go
+++ b/test/fixtures/block_with_many_block.cf.go
@@ -16,8 +16,9 @@ type BlockWithManyBlockInterpreter struct {
 func (i BlockWithManyBlockInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockWithManyBlock",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"block": "Block", "id_field": "IDField"},
+			Name:              "BlockWithManyBlock",
+			Parameters: map[string]schema.Schema{
 				"block": &schema.Array{
 					Items: &schema.Reference{
 						Metadata: schema.Metadata{
@@ -34,7 +35,6 @@ func (i BlockWithManyBlockInterpreter) Schema() schema.Schema {
 					Format: "conflow.ID",
 				},
 			},
-			PropertyNames: map[string]string{"block": "Block", "id_field": "IDField"},
 		}
 	}
 	return i.s

--- a/test/fixtures/block_with_one_block.cf.go
+++ b/test/fixtures/block_with_one_block.cf.go
@@ -16,8 +16,9 @@ type BlockWithOneBlockInterpreter struct {
 func (i BlockWithOneBlockInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
-			Name: "BlockWithOneBlock",
-			Properties: map[string]schema.Schema{
+			JSONPropertyNames: map[string]string{"block": "Block", "id_field": "IDField"},
+			Name:              "BlockWithOneBlock",
+			Parameters: map[string]schema.Schema{
 				"block": &schema.Reference{
 					Metadata: schema.Metadata{
 						Pointer: true,
@@ -32,7 +33,6 @@ func (i BlockWithOneBlockInterpreter) Schema() schema.Schema {
 					Format: "conflow.ID",
 				},
 			},
-			PropertyNames: map[string]string{"block": "Block", "id_field": "IDField"},
 		}
 	}
 	return i.s

--- a/tests/acceptance/main.cf.go
+++ b/tests/acceptance/main.cf.go
@@ -17,7 +17,7 @@ func (i MainInterpreter) Schema() schema.Schema {
 	if i.s == nil {
 		i.s = &schema.Object{
 			Name: "Main",
-			Properties: map[string]schema.Schema{
+			Parameters: map[string]schema.Schema{
 				"id": &schema.String{
 					Metadata: schema.Metadata{
 						Annotations: map[string]string{"block.conflow.io/id": "true"},


### PR DESCRIPTION
The schema.Object's Properties parameter has the Conflow parameter names as keys, but the JSON property names should be used when JSON marshalling/unmarshalling.

For this purpose this PR introduces the following changes:
 - add fieldNames map to the object schema: json property name -> field name mapping
 - add parameterNames map to the object schema: json property name -> parameter name mapping

Our schema.Object will still contain the data in a format that's useful for us, so some conversion will happen in MarshalJSON()/UnmarshalJSON().